### PR TITLE
Remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-miklb.dev


### PR DESCRIPTION
Otherwise Github sends you a nice message that says "The CNAME `miklb.dev` is already taken."